### PR TITLE
Fix multiple reinitialization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Ux4iotContextProvider } from './library/Ux4iotContext';
 import { TestInvokeDirectMethod } from './TestInvokeDirectMethod';
 import { TestPatchDesiredProperties } from './TestPatchDesiredProperties';
@@ -8,74 +8,98 @@ import { TestSubscriber } from './TestSubscriber';
 
 const { REACT_APP_UX4IOT_CONNECTION_STRING } = process.env;
 
+const useRerender = (n: number) => {
+	const [counter, setCounter] = useState(0);
+
+	useEffect(() => {
+		if (counter < n) {
+			setCounter(counter + 1);
+		}
+	}, [counter, n]);
+
+	return counter;
+};
+
 function App(): JSX.Element | null {
-	const [showApp, setShowApp] = useState(false);
+	const [reload, setReload] = useState(0);
+	const [showApp, setShowApp] = useState(true);
 	const [showApp2, setShowApp2] = useState(false);
 	const [showApp3, setShowApp3] = useState(false);
 	const [showApp4, setShowApp4] = useState(false);
+	const [kill, setKill] = useState(false);
+	const rerender = useRerender(20);
 	if (!REACT_APP_UX4IOT_CONNECTION_STRING) {
 		console.error('REACT_APP_UX4IOT_CONNECTION_STRING is missing.');
 		return null;
 	}
+
+	console.log('app rerender', rerender);
+
 	return (
-		<div className="App">
-			<Ux4iotContextProvider
-				options={{ adminConnectionString: REACT_APP_UX4IOT_CONNECTION_STRING }}
-			>
-				<div>
-					<label>Show App ?</label>
-					<input
-						type="checkbox"
-						checked={showApp}
-						onChange={() => setShowApp(!showApp)}
-					/>
-					{showApp && (
-						<TestSubscriber datapoints={[]} deviceId="simulated-device" />
-					)}
-				</div>
-				<div>
-					<label>Show App ?</label>
-					<input
-						type="checkbox"
-						checked={showApp2}
-						onChange={() => setShowApp2(!showApp2)}
-					/>
-					{showApp2 && (
-						<TestSubscriber datapoints={[]} deviceId="simulated-device" />
-					)}
-				</div>
-				<div>
-					<label>Show App ?</label>
-					<input
-						type="checkbox"
-						checked={showApp3}
-						onChange={() => setShowApp3(!showApp3)}
-					/>
-					{showApp3 && (
-						<TestSingleSubscriber
-							deviceId="simulated-device"
-							datapointName="temperature"
+		<div key={reload} className="App">
+			<button onClick={() => setReload(reload === 0 ? 1 : 0)}>Reload</button>
+			{!kill && (
+				<Ux4iotContextProvider
+					options={{
+						adminConnectionString: REACT_APP_UX4IOT_CONNECTION_STRING,
+					}}
+				>
+					<div>
+						<label>Show App ?</label>
+						<input
+							type="checkbox"
+							checked={showApp}
+							onChange={() => setShowApp(!showApp)}
 						/>
-					)}
-				</div>
-				<div>
-					<label>Show App ?</label>
-					<input
-						type="checkbox"
-						checked={showApp4}
-						onChange={() => setShowApp4(!showApp4)}
-					/>
-					{showApp4 && (
-						<TestRawD2CMessageSubscriber deviceId="simulated-device" />
-					)}
-				</div>
-				<div>
-					<TestInvokeDirectMethod deviceId="simulated-device" />
-				</div>
-				<div>
-					<TestPatchDesiredProperties deviceId="simulated-device" />
-				</div>
-			</Ux4iotContextProvider>
+						{showApp && (
+							<TestSubscriber datapoints={[]} deviceId="simulated-device" />
+						)}
+					</div>
+					<div>
+						<label>Show App ?</label>
+						<input
+							type="checkbox"
+							checked={showApp2}
+							onChange={() => setShowApp2(!showApp2)}
+						/>
+						{showApp2 && (
+							<TestSubscriber datapoints={[]} deviceId="simulated-device" />
+						)}
+					</div>
+					<div>
+						<label>Show App ?</label>
+						<input
+							type="checkbox"
+							checked={showApp3}
+							onChange={() => setShowApp3(!showApp3)}
+						/>
+						{showApp3 && (
+							<TestSingleSubscriber
+								deviceId="simulated-device"
+								datapointName="temperature"
+							/>
+						)}
+					</div>
+					<div>
+						<label>Show App ?</label>
+						<input
+							type="checkbox"
+							checked={showApp4}
+							onChange={() => setShowApp4(!showApp4)}
+						/>
+						{showApp4 && (
+							<TestRawD2CMessageSubscriber deviceId="simulated-device" />
+						)}
+					</div>
+					<div>
+						<TestInvokeDirectMethod deviceId="simulated-device" />
+					</div>
+					<div>
+						<TestPatchDesiredProperties deviceId="simulated-device" />
+					</div>
+				</Ux4iotContextProvider>
+			)}
+			<button onClick={() => setKill(!kill)}>{kill ? 'Revive' : 'Kill'}</button>
 		</div>
 	);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,8 @@ function App(): JSX.Element | null {
 	const [showApp3, setShowApp3] = useState(false);
 	const [showApp4, setShowApp4] = useState(false);
 	const [kill, setKill] = useState(false);
-	const rerender = useRerender(20);
+	const [renders, setRenders] = useState(20);
+	const rerender = useRerender(renders);
 	if (!REACT_APP_UX4IOT_CONNECTION_STRING) {
 		console.error('REACT_APP_UX4IOT_CONNECTION_STRING is missing.');
 		return null;
@@ -37,7 +38,14 @@ function App(): JSX.Element | null {
 
 	return (
 		<div key={reload} className="App">
-			<button onClick={() => setReload(reload === 0 ? 1 : 0)}>Reload</button>
+			<button
+				onClick={() => {
+					setReload(reload === 0 ? 1 : 0);
+					setRenders(renders + 20);
+				}}
+			>
+				Reload
+			</button>
 			{!kill && (
 				<Ux4iotContextProvider
 					options={{

--- a/src/TestSubscriber.tsx
+++ b/src/TestSubscriber.tsx
@@ -9,23 +9,20 @@ type Props = {
 };
 
 export const TestSubscriber: FC<Props> = ({ deviceId }) => {
-	const { telemetry, toggleTelemetry, isSubscribed, currentSubscribers } =
-		useMultiTelemetry({
-			initialSubscribers: { [deviceId]: ['temperature', 'pressure'] },
-			onData: (deviceId, key, value) =>
-				console.log('useMultiTelemetry', deviceId, key, value),
-			onGrantError: error => console.log(error),
-		});
+	const { telemetry, toggleTelemetry, isSubscribed } = useMultiTelemetry({
+		initialSubscribers: { [deviceId]: ['temperature', 'pressure'] },
+		onData: (deviceId, key, value) =>
+			console.log('useMultiTelemetry', deviceId, key, value),
+		onGrantError: error => console.log(error),
+	});
 	const [myState, setMyState] = useState<number>(0);
 	const twin = useDeviceTwin(deviceId, {
 		onData: twin => {
 			setMyState(myState + 1);
-			console.log('prevstate', twin, myState);
 		},
 		onGrantError: error => console.log(error),
 	});
 	const connectionState = useConnectionState(deviceId);
-	console.log(currentSubscribers);
 
 	return (
 		<div style={{ display: 'flex' }}>

--- a/src/library/Ux4iot.ts
+++ b/src/library/Ux4iot.ts
@@ -113,7 +113,7 @@ export class Ux4iot {
 
 	private log(...args: any[]) {
 		if (this.devMode) {
-			console.warn('Ux4iot:', ...args);
+			console.warn('ux4iot:', ...args);
 		}
 	}
 

--- a/src/library/Ux4iotContext.tsx
+++ b/src/library/Ux4iotContext.tsx
@@ -3,6 +3,7 @@ import {
 	createContext,
 	ReactNode,
 	useEffect,
+	useRef,
 	useState,
 } from 'react';
 import { InitializationOptions } from './types';
@@ -22,16 +23,25 @@ export const Ux4iotContextProvider: ComponentType<Ux4iotProviderProps> = ({
 	children,
 }) => {
 	const [ux4iot, setUx4iot] = useState<Ux4iot>();
+	const initializing = useRef(false);
 
 	useEffect(() => {
 		async function initialize() {
-			if (!ux4iot) {
+			if (!ux4iot && !initializing.current) {
+				initializing.current = true;
 				const instance = await Ux4iot.create(options);
 				setUx4iot(instance);
+				initializing.current = false;
 			}
 		}
 		initialize();
 	}, [options, ux4iot]);
+
+	useEffect(() => {
+		return () => {
+			ux4iot?.destroy();
+		};
+	}, [ux4iot]);
 
 	return (
 		<Ux4iotContext.Provider value={ux4iot}>{children}</Ux4iotContext.Provider>


### PR DESCRIPTION
## Bug description
Whenever a component rerendered, that was rendering a Ux4iotContextProvider, the socket was not destroyed. Afterwards, multiple active sockets were still subscribed to data, which was not consumed. This was because 
- the initialization of the Ux4iot Socket is asynchronous which caused race conditions
- multiple side-by-side initializations were allowed
- the sockets weren't disconnected whenever the Ux4iotContextProvider unmounted

## Solution
- A ref in the Ux4iotContextProvider, checking whether the ux4iot is currently initialized
- A dedicated useEffect to call the destroy function on a potentially active ux4iot instance
- Additional checks for client or server disconnects within the Ux4iot class

### Notes
Some console.logs were deleted and the Testing App now has more options to simulate real app situations like unmounts, multiple reloads, etc.