### PR TITLE
Fix retry timeout on socket server error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ function App(): JSX.Element | null {
 	const [reload, setReload] = useState(0);
 	const [showApp, setShowApp] = useState(false);
 	const [showApp2, setShowApp2] = useState(false);
-	const [showApp3, setShowApp3] = useState(true);
+	const [showApp3, setShowApp3] = useState(false);
 	const [showApp4, setShowApp4] = useState(false);
 	const [kill, setKill] = useState(false);
 	const [renders, setRenders] = useState(20);

--- a/src/library/Ux4iot.ts
+++ b/src/library/Ux4iot.ts
@@ -49,6 +49,7 @@ const DISCONNECTED_MESSAGE = `Disconnected / Error Connecting. Trying to reconne
 const INIT_ERROR_MESSAGE = `Failed to fetch sessionId of ux4iot. Attempting again in ${
 	RECONNECT_TIMEOUT / 1000
 } seconds.`;
+const CLIENT_DISCONNECTED_MESSAGE = 'Client manually disconnected';
 
 const defaultGrantRequestFunction = (
 	baseURL: string,
@@ -165,7 +166,7 @@ export class Ux4iot {
 	destroy(): void {
 		this.socket?.disconnect();
 		this.socket = undefined;
-		this.log('socket with id ', this.sessionId, ' destroyed');
+		this.log('socket with id', this.sessionId, 'destroyed');
 	}
 
 	private async initSessionId(): Promise<void | string> {
@@ -184,9 +185,13 @@ export class Ux4iot {
 	}
 
 	private onErrorOrDisconnect(error: unknown) {
-		this.log(DISCONNECTED_MESSAGE, error);
-		this.socket = undefined;
-		this.tryReconnect();
+		if (error === 'io client disconnect') {
+			this.log(CLIENT_DISCONNECTED_MESSAGE, error);
+		} else {
+			this.log(DISCONNECTED_MESSAGE, error);
+			this.socket = undefined;
+			this.tryReconnect();
+		}
 	}
 
 	private tryReconnect() {


### PR DESCRIPTION
Previously we just had a restart mechanism in place to resubscribe in case of server disconnect events. If the server threw an error we didnt subscribe after the server was restarted. 
This fix resubscribes all registered subscriptions, regardless of the reason, the ux4iot server might not be available.