### PR TITLE
Enable long polling as fallback to ws

### DIFF
--- a/src/library/base/Ux4iot.ts
+++ b/src/library/base/Ux4iot.ts
@@ -81,7 +81,7 @@ export class Ux4iot {
 
 	private initializeSocket() {
 		const socketURI = this.api.getSocketURL(this.sessionId);
-		this.socket = io(socketURI, { transports: ['websocket'] });
+		this.socket = io(socketURI, { transports: ['websocket', 'polling'] });
 		this.socket.on('connect', this.onConnect.bind(this));
 		this.socket.on('connect_error', this.onConnectError.bind(this));
 		this.socket.on('disconnect', this.onDisconnect.bind(this));


### PR DESCRIPTION
As a fix for infrastructures where websockets are disallowed, see https://deviceinsight.atlassian.net/browse/UX4IOT-241

See https://socket.io/docs/v3/client-initialization/#low-level-engine-options